### PR TITLE
Live Push 2022-10-14: fix vite compiling scss on `justatic/hazel`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justia/lazyframe",
   "description": "Dependency-free library for lazyloading iframes",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "author": "Viktor Bergehall",
   "bugs": {
     "url": "https://github.com/justia/lazyframe/issues"

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "ava": "^3.15.0",
     "jsdom": "15",
     "rollup": "^2.39.0",
+    "rollup-plugin-modify": "^3.0.0",
     "rollup-plugin-scss": "^3.0.0",
     "rollup-plugin-terser": "^7.0.2",
     "sass": "^1.42.1"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,6 +1,7 @@
 import { babel } from "@rollup/plugin-babel";
 import { terser } from "rollup-plugin-terser";
 import scss from "rollup-plugin-scss";
+import modify from 'rollup-plugin-modify'
 
 export default {
   input: "src/lazyframe.js",
@@ -12,6 +13,10 @@ export default {
     sourcemap: false,
   },
   plugins: [
+    modify({
+      find: "import './scss/lazyframe.scss?raw';",
+      replace: "import './scss/lazyframe.scss';",
+    }),
     babel({
       exclude: "node_modules/**",
       babelHelpers: "bundled",

--- a/src/lazyframe.js
+++ b/src/lazyframe.js
@@ -1,4 +1,4 @@
-import './scss/lazyframe.scss'
+import './scss/lazyframe.scss?raw';
 
 const Lazyframe = () => {
     let settings;


### PR DESCRIPTION
Adding `?raw` prevents vite from compiling the scss and adding the import to `main.js` causing the generated css not to be found.

---

## General

### Code Refactoring

- Add ?raw to fix vite error in justatic (ade32c7efc77802cfede6096da60d6a73614c94c)

### Chore

- Update build config to avoid error (92edfed4a72606f9f4b2142c65ff3703085bedd4)
- Update version (f978682a3bf91441443e10e5463f5deaaff509b6)

---
Related to https://github.com/justia/justatic/pull/3200
