### PR TITLE
[2024-08-20] [LIVE] [General] Match npm package version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justia/lazyframe",
   "description": "Dependency-free library for lazyloading iframes",
-  "version": "2.3.3",
+  "version": "2.3.4",
   "author": "Viktor Bergehall",
   "bugs": {
     "url": "https://github.com/justia/lazyframe/issues"


### PR DESCRIPTION
## General

### Bug Fixes

- Match npm version (4ae6b06b8ee7d9761d82149e62f46107984042f0)


 ---
 