### PR TITLE
[2025-12-16] [LIVE] [General] Expose Missing Types

### DIFF
--- a/dist/lazyframe.d.ts
+++ b/dist/lazyframe.d.ts
@@ -3,7 +3,7 @@ type Vendor = 'youtube' | 'youtube_nocookie' | 'vimeo';
 type AspectRatio = '16:9' | '4:3' | '1:1';
 type StringBoolean = 'true' | 'false';
 type ConvertStringBool<T> = T extends StringBoolean ? boolean : T;
-type LazyframeOptions = {
+export type LazyframeOptions = {
     lazyload?: boolean;
     autoplay?: boolean;
     initinview?: boolean;
@@ -13,7 +13,7 @@ type LazyframeOptions = {
     onAppend?: (iframe: HTMLIFrameElement) => void;
     onThumbnailLoad?: (imgUrl: string) => void;
 };
-type LazyframeDatasetStringOptions = {
+export type LazyframeDatasetStringOptions = {
     src: string;
     vendor?: Vendor;
     title?: string;
@@ -28,7 +28,7 @@ type LazyframeDatasetStringOptions = {
 type LazyframeDatasetOptions = {
     [K in keyof LazyframeDatasetStringOptions]: ConvertStringBool<LazyframeDatasetStringOptions[K]>;
 };
-interface HTMLLazyframeElement extends HTMLElement {
+export interface HTMLLazyframeElement extends HTMLElement {
     dataset: LazyframeDatasetStringOptions;
 }
 type LazyframeSettings = LazyframeOptions & Omit<LazyframeDatasetOptions, 'thumbnail'> & {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@justia/lazyframe",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@justia/lazyframe",
-      "version": "2.5.0",
+      "version": "2.5.1",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-terser": "^0.4.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justia/lazyframe",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "Dependency-free library for lazyloading iframes",
   "bugs": {
     "url": "https://github.com/justia/lazyframe/issues"

--- a/src/lazyframe.ts
+++ b/src/lazyframe.ts
@@ -9,7 +9,7 @@ type StringBoolean = 'true' | 'false';
 type ConvertStringBool<T> = T extends StringBoolean ? boolean : T;
 
 // Options the user can set during a programmatic initialization.
-type LazyframeOptions = {
+export type LazyframeOptions = {
     lazyload?: boolean;
     autoplay?: boolean;
     initinview?: boolean;
@@ -21,7 +21,7 @@ type LazyframeOptions = {
 };
 
 // Defines all the possible `data-*` attributes that the element could have.
-type LazyframeDatasetStringOptions = {
+export type LazyframeDatasetStringOptions = {
     src: string;
     vendor?: Vendor;
     title?: string;
@@ -39,7 +39,7 @@ type LazyframeDatasetOptions = {
     [K in keyof LazyframeDatasetStringOptions]: ConvertStringBool<LazyframeDatasetStringOptions[K]>;
 };
 
-interface HTMLLazyframeElement extends HTMLElement {
+export interface HTMLLazyframeElement extends HTMLElement {
     dataset: LazyframeDatasetStringOptions;
 }
 


### PR DESCRIPTION
## Fixes & Improvements

- **Improved Access to Public Options and Element Types**
	- We've made it easier for users to access important public options and element types. This means you can now work with `LazyframeOptions`, `LazyframeDatasetStringOptions`, and `HTMLLazyframeElement` without having to redefine internal types, streamlining your experience.

## Other Updates

- **Version Update**
	- The software has been updated to version 2.5.1, ensuring you have the latest features and improvements. 
